### PR TITLE
Updates for reflex-dom-0.5

### DIFF
--- a/reflex-indexed-db.cabal
+++ b/reflex-indexed-db.cabal
@@ -16,19 +16,20 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   exposed-modules:     Reflex.IDB
-  build-depends:       base >= 4.7 && < 5
+  build-depends:       base            >= 4.7 && < 5
                      , ghcjs-base
                      , ghcjs-dom
                      , text
                      , aeson
                      , bytestring
-                     , transformers >= 0.4
-                     , free >= 4.12
-                     , dependent-map >= 0.2
-                     , data-default >= 0.5
-                     , ref-tf >= 0.4
-                     , reflex        >= 0.4
-                     , reflex-dom    >= 0.3
+                     , transformers    >= 0.4
+                     , free            >= 4.12
+                     , dependent-map   >= 0.2
+                     , data-default    >= 0.5
+                     , ref-tf          >= 0.4
+                     , reflex          >= 0.6 && < 0.7
+                     , reflex-dom-core >= 0.5 && < 0.6
+                     , reflex-dom
   default-language:    Haskell2010
 
 test-suite reflex-indexdb-test
@@ -37,9 +38,9 @@ test-suite reflex-indexdb-test
   main-is:             Spec.hs
   build-depends:       base
                      , reflex-indexed-db
-                     , reflex-dom >= 0.3
+                     , reflex-dom
                      , text
-                     , transformers >= 0.4
+                     , transformers
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 

--- a/reflex-indexed-db.cabal
+++ b/reflex-indexed-db.cabal
@@ -37,6 +37,7 @@ test-suite reflex-indexdb-test
   hs-source-dirs:      test
   main-is:             Spec.hs
   build-depends:       base
+                     , ghcjs-dom
                      , reflex-indexed-db
                      , reflex-dom
                      , text


### PR DESCRIPTION
Most of of the changes in this PR are small adjustments for changes in the ghcjs-dom API - a lot of functions take `ToJSVal a => a` rather than `JSVal`, or return `a` instead of `Maybe a`.

The hard part, which I haven't figured out, is how to deal with the `onSuccess` and `onUpgradeNeeded` callbacks. I just don't understand this part of the reflex host yet.