### PR TITLE
Drop reflex-dom from library dependencies

### DIFF
--- a/reflex-indexed-db.cabal
+++ b/reflex-indexed-db.cabal
@@ -29,7 +29,6 @@ library
                      , ref-tf          >= 0.4
                      , reflex          >= 0.6 && < 0.7
                      , reflex-dom-core >= 0.5 && < 0.6
-                     , reflex-dom
   default-language:    Haskell2010
 
 test-suite reflex-indexdb-test


### PR DESCRIPTION
Addresses #1 

Tested locally. :+1: