### PR TITLE
Allow jsaddle

### DIFF
--- a/reflex-indexed-db.cabal
+++ b/reflex-indexed-db.cabal
@@ -17,7 +17,6 @@ library
   hs-source-dirs:      src
   exposed-modules:     Reflex.IDB
   build-depends:       base            >= 4.7 && < 5
-                     , ghcjs-base
                      , ghcjs-dom
                      , text
                      , aeson
@@ -29,7 +28,6 @@ library
                      , ref-tf          >= 0.4
                      , reflex          >= 0.6 && < 0.7
                      , reflex-dom-core >= 0.5 && < 0.6
-                     , reflex-dom
   default-language:    Haskell2010
 
 test-suite reflex-indexdb-test


### PR DESCRIPTION
This change drops the ghcjs-base dependency and runs in the JSM monad where appropriate to support use by ghcjs-dom-jsaddle for compiling with ghc and running natively

Tested locally :+1:. The test application builds and runs, adding an item happily prints to the console.