### PR TITLE
Allow storage of Aeson.Value as DB item

### DIFF
--- a/reflex-indexed-db.cabal
+++ b/reflex-indexed-db.cabal
@@ -35,6 +35,7 @@ test-suite reflex-indexdb-test
   hs-source-dirs:      test
   main-is:             Spec.hs
   build-depends:       base
+                     , aeson
                      , ghcjs-dom
                      , reflex-indexed-db
                      , reflex-dom

--- a/src/Reflex/IDB.hs
+++ b/src/Reflex/IDB.hs
@@ -258,7 +258,7 @@ currentUpdate item = Cursor $ liftF $ OpCurUpdate item ()
 currentDelete :: (Monad m) => Cursor t s m ()
 currentDelete = Cursor $ liftF $ OpCurDelete ()
 
-type Item = Text
+type Item = A.Value
 
 newtype Cursor t s m a = Cursor { runCursor :: FreeT (CursorOp t Item) (ExceptT IDBError (StateT s m)) a}
                        deriving ( Functor

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -2,6 +2,7 @@
 
 import Reflex.IDB
 import Reflex.Dom
+import qualified Data.Aeson as A
 import qualified Data.Text as T
 import Control.Monad.IO.Class
 import qualified GHCJS.DOM.Enums as DOM
@@ -23,8 +24,8 @@ testIDB = mainWidget $ do
   tres <- runTransaction idb (TransactionConfig ["todo"] DOM.IDBTransactionModeReadwrite todoAddE never) $ do
     todoSt <- openStore "todo"
     inp <- getInput
-    add todoSt (T.pack "testV") (Just $ inp)
-    add todoSt (T.pack "testV") (Just $ inp <> "_1")
+    add todoSt (A.String "testV") (Just $ inp)
+    add todoSt (A.object ["name" A..= T.pack "byteally"]) (Just $ inp <> "_1")
     liftIO $ print inp
     return ()
   text "Is DB Open: "


### PR DESCRIPTION
A quick validation (the "10" keys were created on a previous run, "hello" keys are from this branch)

![2019-11-25-170714_1235x329_scrot](https://user-images.githubusercontent.com/993484/69582266-35cf7e80-0fa6-11ea-8f0b-30c72bfa30e2.png)
